### PR TITLE
Added Sample Variance & SD

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Descriptive Statistics
 Overview
 --------
 
-This gem adds methods to the Enumerable module to allow easy calculation of basic 
+This gem adds methods to the Enumerable module to allow easy calculation of basic
 descriptive statistics of Numeric sample data in collections that have included Enumerable such as Array, Hash, Set, and Range. The statistics that can be calculated are:
 * Number
 * Sum
@@ -13,6 +13,8 @@ descriptive statistics of Numeric sample data in collections that have included 
 * Mode
 * Variance
 * Standard Deviation
+* Sample Variance
+* Sample Standard Deviation
 * Percentile
 * Percentile Rank
 * Descriptive Statistics
@@ -23,23 +25,27 @@ When requiring DescriptiveStatistics, the Enumerable module is monkey patched so
 that the statistical methods are available on any instance of a class that has included Enumerable. For example with an Array:
 ```
 > require 'descriptive_statistics'
- => true 
+ => true
 > data = [2,6,9,3,5,1,8,3,6,9,2]
- => [2, 6, 9, 3, 5, 1, 8, 3, 6, 9, 2] 
+ => [2, 6, 9, 3, 5, 1, 8, 3, 6, 9, 2]
 > data.number
- => 11.0 
+ => 11.0
 > data.sum
  => 54.0
 > data.mean
- => 4.909090909090909 
+ => 4.909090909090909
 > data.median
- => 5.0 
+ => 5.0
 > data.variance
- => 7.7190082644628095 
+ => 7.7190082644628095
+> data.sample_variance
+ => 8.490909090909090
 > data.standard_deviation
- => 2.778310325442932 
+ => 2.778310325442932
+> data.sample_standard_deviation
+ => 2.91391645228704
 > data.percentile(30)
- => 3.0 
+ => 3.0
 > data.percentile(70)
  => 6.0
 > data.percentile_rank(8)
@@ -49,39 +55,39 @@ that the statistical methods are available on any instance of a class that has i
 > data.range
  => 8
 > data.descriptive_statistics
- => {:number=>11.0, 
-  :sum=>54, 
-  :variance=>7.7190082644628095, 
-  :standard_deviation=>2.778310325442932, 
-  :min=>1, 
-  :max=>9, 
-  :mean=>4.909090909090909, 
-  :mode=>2, 
-  :median=>5.0, 
-  :range=>8.0, 
-  :q1=>2.5, 
-  :q2=>5.0, 
+ => {:number=>11.0,
+  :sum=>54,
+  :variance=>7.7190082644628095,
+  :standard_deviation=>2.778310325442932,
+  :min=>1,
+  :max=>9,
+  :mean=>4.909090909090909,
+  :mode=>2,
+  :median=>5.0,
+  :range=>8.0,
+  :q1=>2.5,
+  :q2=>5.0,
   :q3=>7.0}
 ```
 
 and with other types of objects:
 ```
 > require 'set'
-=> true 
+=> true
 > require 'descriptive_statistics'
-=> true 
+=> true
 > {:a=>1, :b=>2, :c=>3, :d=>4, :e=>5}.mean #Hash
-=> 3.0 
+=> 3.0
 > Set.new([1,2,3,4,5]).mean #Set
-=> 3.0 
+=> 3.0
 > (1..5).mean #Range
-=> 3.0 
+=> 3.0
 ```
 
-including instances of your own classes, when an `each` method is provided that 
+including instances of your own classes, when an `each` method is provided that
 creates an Enumerator over the sample data to be operated upon:
 ```
-class Foo 
+class Foo
   include Enumerable
   attr_accessor :bar, :baz, :bat
 
@@ -101,7 +107,7 @@ foo.mean
 
 or:
 ```
-class Foo 
+class Foo
   include Enumerable
   attr_accessor :bar, :baz, :bat
 
@@ -131,45 +137,45 @@ bowling.john = 134
 bowling.peter = 233
 bowling.mean
 => 190.0
-``` 
+```
 
 
-Alternatively, you can extend DescriptiveStatistics on individual objects by 
+Alternatively, you can extend DescriptiveStatistics on individual objects by
 requiring DescriptiveStatistics safely, thus avoiding the monkey patch. For example:
 ```
 > require 'descriptive_statistics/safe'
  => true
 > data = [2,6,9,3,5,1,8,3,6,9,2]
- => [2, 6, 9, 3, 5, 1, 8, 3, 6, 9, 2] 
+ => [2, 6, 9, 3, 5, 1, 8, 3, 6, 9, 2]
 > data.extend(DescriptiveStatistics)
- => [2, 6, 9, 3, 5, 1, 8, 3, 6, 9, 2] 
+ => [2, 6, 9, 3, 5, 1, 8, 3, 6, 9, 2]
 > data.number
- => 11.0 
+ => 11.0
 > data.sum
- => 54 
+ => 54
 ```
 
-Or, if you prefer leaving your collection pristine, you can create a 
+Or, if you prefer leaving your collection pristine, you can create a
 Stats object that references your collection:
 ```
 > require 'descriptive_statistics/safe'
- => true 
+ => true
 > data = [1, 2, 3, 4, 5, 1]
- => [1, 2, 3, 4, 5, 1] 
+ => [1, 2, 3, 4, 5, 1]
 > stats = DescriptiveStatistics::Stats.new(data)
- => [1, 2, 3, 4, 5, 1] 
+ => [1, 2, 3, 4, 5, 1]
 > stats.class
- => DescriptiveStatistics::Stats 
+ => DescriptiveStatistics::Stats
 > stats.mean
- => 2.6666666666666665 
+ => 2.6666666666666665
 > stats.median
- => 2.5 
+ => 2.5
 > stats.mode
- => 1 
+ => 1
 > data << 2
- => [1, 2, 3, 4, 5, 1, 2] 
+ => [1, 2, 3, 4, 5, 1, 2]
 > data << 2
- => [1, 2, 3, 4, 5, 1, 2, 2] 
+ => [1, 2, 3, 4, 5, 1, 2, 2]
 > stats.mode
  => 2
 ```
@@ -177,13 +183,13 @@ Stats object that references your collection:
 Or you call the statistical methods directly:
 ```
 > require 'descriptive_statistics/safe'
- => true 
+ => true
 > DescriptiveStatistics.mean([1,2,3,4,5])
- => 3.0 
+ => 3.0
 > DescriptiveStatistics.mode([1,2,3,4,5])
- => 1 
+ => 1
 > DescriptiveStatistics.variance([1,2,3,4,5])
- => 2.0 
+ => 2.0
 ```
 
 Notes
@@ -220,8 +226,8 @@ Ports
 
 License
 -------
-Copyright (c) 2010-2014 
-Derrick Parkhurst (derrick.parkhurst@gmail.com), 
+Copyright (c) 2010-2014
+Derrick Parkhurst (derrick.parkhurst@gmail.com),
 Gregory Brown (gregory.t.brown@gmail.com),
 Daniel Farrell (danielfarrell76@gmail.com),
 Graham Malmgren,

--- a/lib/descriptive_statistics/standard_deviation.rb
+++ b/lib/descriptive_statistics/standard_deviation.rb
@@ -5,4 +5,11 @@ module DescriptiveStatistics
 
     Math.sqrt(values.variance)
   end
+
+  def sample_standard_deviation(collection = self)
+    values = Support::convert(collection)
+    return unless values.size > 0
+
+    Math.sqrt(values.sample_variance)
+  end
 end

--- a/lib/descriptive_statistics/variance.rb
+++ b/lib/descriptive_statistics/variance.rb
@@ -6,4 +6,12 @@ module DescriptiveStatistics
     mean = values.mean
     values.map{ |sample| (mean - sample) ** 2 }.inject(:+) / values.number
   end
+
+  def sample_variance(collection = self)
+    values = Support::convert(collection)
+    return unless values.size > 0
+
+    mean = values.mean
+    values.map{ |sample| (mean - sample) ** 2 }.inject(:+) / [values.number - 1, 1].max
+  end
 end

--- a/spec/array_spec.rb
+++ b/spec/array_spec.rb
@@ -29,12 +29,20 @@ describe "DescriptiveStatistics" do
       expect(subject.median).to eql(5.0)
     end
 
-    it "calculates the variance" do
+    it "calculates the [population] variance" do
       expect(subject.variance).to eql(7.7190082644628095)
     end
 
-    it "calculates the standard_deviation" do
+    it "calculates the sample_variance" do
+      expect(subject.sample_variance).to eql(8.490909090909090)
+    end
+
+    it "calculates the [population] standard_deviation" do
       expect(subject.standard_deviation).to eql(2.778310325442932)
+    end
+
+    it "calculates the sample_standard_deviation" do
+      expect(subject.sample_standard_deviation).to eql(2.91391645228704)
     end
 
     it "calculates the percentile" do

--- a/spec/class_method_spec.rb
+++ b/spec/class_method_spec.rb
@@ -24,12 +24,20 @@ describe "DescriptiveStatistics::Stats" do
       expect(subject.median(data)).to eql(5.0)
     end
 
-    it "calculates the variance" do
+    it "calculates the [population] variance" do
       expect(subject.variance(data)).to eql(7.7190082644628095)
     end
 
-    it "calculates the standard_deviation" do
+    it "calculates the sample_variance" do
+      expect(subject.sample_variance(data)).to eql(8.490909090909090)
+    end
+
+    it "calculates the [population] standard_deviation" do
       expect(subject.standard_deviation(data)).to eql(2.778310325442932)
+    end
+
+    it "calculates the sample_standard_deviation" do
+      expect(subject.sample_standard_deviation(data)).to eql(2.91391645228704)
     end
 
     it "calculates the percentile" do

--- a/spec/extend_spec.rb
+++ b/spec/extend_spec.rb
@@ -34,12 +34,20 @@ describe "DescriptiveStatistics" do
       expect(subject.median).to eql(5.0)
     end
 
-    it "calculates the variance" do
+    it "calculates the [population] variance" do
       expect(subject.variance).to eql(7.7190082644628095)
     end
 
-    it "calculates the standard_deviation" do
+    it "calculates the sample_variance" do
+      expect(subject.sample_variance).to eql(8.490909090909090)
+    end
+
+    it "calculates the [population] standard_deviation" do
       expect(subject.standard_deviation).to eql(2.778310325442932)
+    end
+
+    it "calculates the sample_standard_deviation" do
+      expect(subject.sample_standard_deviation).to eql(2.91391645228704)
     end
 
     it "calculates the percentile" do

--- a/spec/hash_spec.rb
+++ b/spec/hash_spec.rb
@@ -29,12 +29,20 @@ describe "DescriptiveStatistics" do
       expect(subject.median).to eql(5.0)
     end
 
-    it "calculates the variance" do
+    it "calculates the [population] variance" do
       expect(subject.variance).to eql(7.7190082644628095)
+    end
+
+    it "calculates the sample_variance" do
+      expect(subject.sample_variance).to eql(8.490909090909090)
     end
 
     it "calculates the standard_deviation" do
       expect(subject.standard_deviation).to eql(2.778310325442932)
+    end
+
+    it "calculates the sample_standard_deviation" do
+      expect(subject.sample_standard_deviation).to eql(2.91391645228704)
     end
 
     it "calculates the percentile" do

--- a/spec/set_spec.rb
+++ b/spec/set_spec.rb
@@ -29,12 +29,20 @@ describe "DescriptiveStatistics" do
       expect(subject.median).to eql(5.0)
     end
 
-    it "calculates the variance" do
+    it "calculates the [population] variance" do
       expect(subject.variance).to eql(7.836734693877552)
     end
 
-    it "calculates the standard_deviation" do
+    it "calculates the sample_variance" do
+      expect(subject.sample_variance).to eql(9.142857142857144)
+    end
+
+    it "calculates the [population] standard_deviation" do
       expect(subject.standard_deviation).to eql(2.799416848895061)
+    end
+
+    it "calculates the sample_standard_deviation" do
+      expect(subject.sample_standard_deviation).to eql(3.023715784073818)
     end
 
     it "calculates the percentile" do

--- a/spec/single_value_spec.rb
+++ b/spec/single_value_spec.rb
@@ -27,8 +27,16 @@ describe "DescriptiveStatistics" do
       expect(subject.variance).to eql(0.0)
     end
 
-    it "calculates the standard_deviation" do
+    it "calculates the sample_variance" do
+      expect(subject.sample_variance).to eql(0.0)
+    end
+
+    it "calculates the [population] standard_deviation" do
       expect(subject.standard_deviation).to eql(0.0)
+    end
+
+    it "calculates the sample_standard_deviation" do
+      expect(subject.sample_standard_deviation).to eql(0.0)
     end
 
     it "calculates the percentile" do

--- a/spec/stats_spec.rb
+++ b/spec/stats_spec.rb
@@ -23,12 +23,20 @@ describe "DescriptiveStatistics::Stats" do
       expect(subject.median).to eql(5.0)
     end
 
-    it "calculates the variance" do
+    it "calculates the [population] variance" do
       expect(subject.variance).to eql(7.7190082644628095)
+    end
+
+    it "calculates the sample_variance" do
+      expect(subject.sample_variance).to eql(8.490909090909090)
     end
 
     it "calculates the standard_deviation" do
       expect(subject.standard_deviation).to eql(2.778310325442932)
+    end
+
+    it "calculates the sample_standard_deviation" do
+      expect(subject.sample_standard_deviation).to eql(2.91391645228704)
     end
 
     it "calculates the percentile" do


### PR DESCRIPTION
The existing methods calculate the 'population' variance and standard
deviation. Added methods to calculate the 'sample' versions of these
quantities, which provide unbiased estimates of the population
parameters when a sample is used to estimate.

P.S. Looks like there were some end-of-line spaces that got truncated automatically by my editor, I'll happily amend to remove these if the commit log noise is an issue. 
