### PR TITLE
Fix Median

### DIFF
--- a/lib/descriptive_statistics/descriptive_statistics.rb
+++ b/lib/descriptive_statistics/descriptive_statistics.rb
@@ -1,7 +1,6 @@
 module DescriptiveStatistics
   def descriptive_statistics(&block)
     return { :number => self.number(&block),
-             :sum => self.sum(&block),
              :variance => self.variance(&block),
              :standard_deviation => self.standard_deviation(&block),
              :min => self.min(&block),

--- a/lib/descriptive_statistics/median.rb
+++ b/lib/descriptive_statistics/median.rb
@@ -3,6 +3,14 @@ module DescriptiveStatistics
     values = Support::convert(collection, &block)
     return DescriptiveStatistics.median_empty_collection_default_value if values.empty?
 
-    values.percentile(50)
+    values.sort!
+
+    if values.size % 2 == 0
+      rank = 0.5 * (values.size - 1)
+      lower, upper = values[rank.floor,2]
+      (lower + upper) / 2
+    else
+      values[(values.size - 1) / 2]
+    end
   end
 end

--- a/lib/descriptive_statistics/safe.rb
+++ b/lib/descriptive_statistics/safe.rb
@@ -1,6 +1,5 @@
 require "descriptive_statistics/support/convert"
 require 'descriptive_statistics/number.rb'
-require 'descriptive_statistics/sum.rb'
 require 'descriptive_statistics/mean.rb'
 require 'descriptive_statistics/median.rb'
 require 'descriptive_statistics/mode.rb'

--- a/lib/descriptive_statistics/sum.rb
+++ b/lib/descriptive_statistics/sum.rb
@@ -1,8 +1,0 @@
-module DescriptiveStatistics
-  def sum(collection = self, &block)
-    values = Support::convert(collection, &block)
-    return DescriptiveStatistics.sum_empty_collection_default_value if values.empty?
-
-    return values.reduce(:+)
-  end
-end


### PR DESCRIPTION
The current median method simply refers to the 50th percentile, which breaks for an array such as `[1.0, 1.0, Float::INFINITY]`