### PR TITLE
Fix mean and variance

### DIFF
--- a/lib/descriptive_statistics/mean.rb
+++ b/lib/descriptive_statistics/mean.rb
@@ -3,6 +3,6 @@ module DescriptiveStatistics
     values = Support::convert(collection, &block)
     return DescriptiveStatistics.mean_empty_collection_default_value if values.empty?
 
-    values.sum / values.number
+    values.sum.to_f / values.number
   end
 end

--- a/lib/descriptive_statistics/variance.rb
+++ b/lib/descriptive_statistics/variance.rb
@@ -4,6 +4,6 @@ module DescriptiveStatistics
     return DescriptiveStatistics.variance_empty_collection_default_value if values.empty?
 
     mean = values.mean.to_f
-    values.map { |sample| (mean - sample) ** 2 }.reduce(:+) / values.number
+    values.map { |sample| (mean - sample) ** 2 }.reduce(:+) / (values.number - 1)
   end
 end

--- a/lib/descriptive_statistics/variance.rb
+++ b/lib/descriptive_statistics/variance.rb
@@ -3,7 +3,7 @@ module DescriptiveStatistics
     values = Support::convert(collection, &block)
     return DescriptiveStatistics.variance_empty_collection_default_value if values.empty?
 
-    mean = values.mean
+    mean = values.mean.to_f
     values.map { |sample| (mean - sample) ** 2 }.reduce(:+) / values.number
   end
 end


### PR DESCRIPTION
Our test platform,

Parameter | Value
------------ | -------------
ruby -v | ruby 2.2.3p173 (2015-08-18 revision 51636) [i686-linux]
rails -v | Rails 4.2.0
gem list descriptive_statistics | descriptive_statistics (2.5.1)
uname -a | Linux me 3.13.0-74-generic #118-Ubuntu SMP Thu Dec 17 22:52:02 UTC 2015 i686 i686 i686 GNU/Linux

Example code,

```ruby
> # Buggy code
> require 'descriptive_statistics'
> data = [2,6,9,3,5,1,8,3,6,9,2]
> data.mean
=> 4
> data.variance
=> 7.7190082644628095
> mean_real = data.inject{ |sum, el| sum + el }.to_f / data.size
=> 4.909090909090909
> sum = data.inject(0){|accum, i| accum +(i - mean_real)**2 }
=> 84.9090909090909
> variance_real = sum/(data.size - 1).to_f
=> 8.49090909090909
```

For example data array, while correct mean value is `4.909090909090909`, it is `4`. Similarly, while correct variance value is `8.49090909090909`, it is `7.7190082644628095`.

SPSS results is,

N	| Mean |	Variance |	Std. Deviation	 | Median | 	Minimum |	Maximum |	Sum
------ | -------- | ------------- | ------------------------------ | ---------- | ----------------- | ------------------- | -----------
11	| 4,91 |        8,491 | 	2,914 | 	          5,00 | 	1	 |               9	|  54
