### PR TITLE
Fix markdown formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Notes
 -----
 * All methods return a Float object except for `mode`, which will return a Numeric object from the collection. `mode` will always return nil for empty collections.
 * All methods return nil when the collection is empty, except for `number`, which returns 0.0. This is a different behavior than [ActiveSupport's Enumerable monkey patch of sum](http://apidock.com/rails/Enumerable/sum), which by deafult returns the Fixnum 0 for empty collections. You can change this behavior by specifying the default value returned for empty collections all at once:
-  ```ruby
+```ruby
 require 'descriptive_statistics'
 [].mean
 # => nil
@@ -246,9 +246,9 @@ DescriptiveStatistics.empty_collection_default_value = 0.0
 # => 0.0
 [].sum
 # => 0.0
-  ```
+```
   or one at a time:
-  ```ruby
+```ruby
 require 'descriptive_statistics'
 [].mean
 # => nil
@@ -266,7 +266,7 @@ DescriptiveStatistics.mean_empty_collection_default_value = 0.0
 # => 0.0
 [].sum
 # => 0.0
-  ```
+```
 
 * The scope of this gem covers [Descriptive Statistics](http://en.wikipedia.org/wiki/Descriptive_statistics) and not Inferential Statistics. From wikipedia:
 


### PR DESCRIPTION
GitHub failed to render these code blocks correctly.

Diff of the changes using Markdown previewer:
<img width="471" alt="screen shot 2018-03-05 at 12 52 50 pm" src="https://user-images.githubusercontent.com/43041/36952395-33044a1e-2074-11e8-84af-f94d07b14e30.png">
