### PR TITLE
Remove :sum since method exists in Ruby >= 2.4

### DIFF
--- a/descriptive_statistics.gemspec
+++ b/descriptive_statistics.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'descriptive_statistics'
-  s.version     = '2.5.1'
-  s.homepage    = 'https://github.com/thirtysixthspan/descriptive_statistics'
+  s.version     = '2.6'
+  s.homepage    = 'https://github.com/strixleviathan/descriptive_statistics'
   s.summary     = 'Descriptive Statistics'
   s.description = 'Adds descriptive statistics methods to Enumerable module for use on collections or Numeric data'
   s.authors     = ['Derrick Parkhurst', 'Gregory Brown', 'Daniel Farrell', 'Graham Malmgren', 'Guy Shechter', 'Charlie Egan']

--- a/lib/descriptive_statistics/descriptive_statistics.rb
+++ b/lib/descriptive_statistics/descriptive_statistics.rb
@@ -1,7 +1,6 @@
 module DescriptiveStatistics
   def descriptive_statistics(&block)
     return { :number => self.number(&block),
-             :sum => self.sum(&block),
              :variance => self.variance(&block),
              :standard_deviation => self.standard_deviation(&block),
              :min => self.min(&block),

--- a/lib/descriptive_statistics/safe.rb
+++ b/lib/descriptive_statistics/safe.rb
@@ -1,6 +1,5 @@
 require "descriptive_statistics/support/convert"
 require 'descriptive_statistics/number.rb'
-require 'descriptive_statistics/sum.rb'
 require 'descriptive_statistics/mean.rb'
 require 'descriptive_statistics/median.rb'
 require 'descriptive_statistics/mode.rb'

--- a/lib/descriptive_statistics/sum.rb
+++ b/lib/descriptive_statistics/sum.rb
@@ -1,8 +1,0 @@
-module DescriptiveStatistics
-  def sum(collection = self, &block)
-    values = Support::convert(collection, &block)
-    return DescriptiveStatistics.sum_empty_collection_default_value if values.empty?
-
-    return values.reduce(:+)
-  end
-end


### PR DESCRIPTION
From https://github.com/thirtysixthspan/descriptive_statistics/commit/f46e04d3eecc829fafb7626a42aa84db1cfc78d0.